### PR TITLE
fixed params for the LinkInfo url

### DIFF
--- a/link-ui/src/main/java/com/tink/link/ui/extensions/StringExtensions.kt
+++ b/link-ui/src/main/java/com/tink/link/ui/extensions/StringExtensions.kt
@@ -56,7 +56,7 @@ internal fun String.convertUrlMarkdownToSpan(context: Context): SpannableString 
         val url = matcher.toMatchResult().group(2)
         val startIndex = matcher.start(1) - 1
         if (!url.isNullOrEmpty() && !linkText.isNullOrEmpty()) {
-            val linkInfo = LinkInfo.Url(url, linkText)
+            val linkInfo = LinkInfo.Url(linkText, url)
             val fullText = matcher.replaceAll(linkText)
             return SpannableString.valueOf(fullText).apply {
                 setSpan(


### PR DESCRIPTION
The StringExtensionsTest failed because the order of parameters for the LinkInfo URL has been changed and the convertUrlMarkdownToSpan method was in wrong order